### PR TITLE
Implement endpoint prompt generation and intent resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # MCP Server
 
-This project is a minimal NestJS server using Fastify. It exposes two endpoints:
+This project is a minimal NestJS server using Fastify. It exposes endpoints to parse OpenAPI files and resolve user intents:
 
-- `POST /upload-openapi` to upload an OpenAPI file.
-- `POST /chat` to echo back the provided message.
+- `POST /upload-openapi` uploads and parses an OpenAPI document. Each endpoint in the spec is stored together with a generated prompt.
+- `POST /chat` resolves a natural language message to the most relevant stored endpoint and returns its information.
 
 Swagger documentation is available at `/api-docs` when running the server.
 

--- a/mcp-server/package-lock.json
+++ b/mcp-server/package-lock.json
@@ -22,6 +22,7 @@
         "pg": "^8.12.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1",
+        "string-similarity": "^4.0.4",
         "typeorm": "^0.3.25"
       },
       "devDependencies": {
@@ -12902,6 +12903,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/string-similarity": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/string-similarity/-/string-similarity-4.0.4.tgz",
+      "integrity": "sha512-/q/8Q4Bl4ZKAPjj8WerIBJWALKkaPRfrvhfF8k/B23i4nzrlRj2/go1m90In7nG/3XDSbOo0+pu6RvCTM9RGMQ==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "license": "ISC"
     },
     "node_modules/string-width": {
       "version": "4.2.3",

--- a/mcp-server/package.json
+++ b/mcp-server/package.json
@@ -33,6 +33,7 @@
     "pg": "^8.12.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1",
+    "string-similarity": "^4.0.4",
     "typeorm": "^0.3.25"
   },
   "devDependencies": {

--- a/mcp-server/src/entities/endpoint.entity.ts
+++ b/mcp-server/src/entities/endpoint.entity.ts
@@ -1,4 +1,11 @@
-import { Column, Entity, JoinColumn, ManyToOne, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
 import { Project } from './project.entity';
 import { RequestParameter } from './request-parameter.entity';
 import { ResponseField } from './response-field.entity';
@@ -20,6 +27,9 @@ export class Endpoint {
 
   @Column({ nullable: true })
   summary: string;
+
+  @Column({ nullable: true })
+  prompt: string;
 
   @ManyToOne(() => Project, (project) => project.endpoints)
   @JoinColumn({ name: 'projectId' })

--- a/mcp-server/src/openapi.controller.ts
+++ b/mcp-server/src/openapi.controller.ts
@@ -12,51 +12,64 @@ export class OpenapiController {
 
   @Post('upload-openapi')
   @ApiOperation({ summary: 'Upload and parse OpenAPI file' })
-  @ApiResponse({ status: 200, description: 'File uploaded and parsed successfully' })
-  async upload(@Req() req: FastifyRequest): Promise<{ 
-    status: string; 
-    projectId: number; 
-    endpointsCount: number; 
+  @ApiResponse({
+    status: 200,
+    description: 'File uploaded and parsed successfully',
+  })
+  async upload(@Req() req: FastifyRequest): Promise<{
+    status: string;
+    projectId: number;
+    endpointsCount: number;
     message: string;
   }> {
     const file = await (req as any).file();
     const filePath = `/tmp/${Date.now()}_${file.filename}`;
     await writeFile(filePath, await file.toBuffer());
-    
+
     const result = await this.openapiService.parseAndStore(filePath);
-    
-    return { 
+
+    return {
       status: 'success',
       projectId: result.projectId,
       endpointsCount: result.endpointsCount,
-      message: `Successfully parsed ${result.endpointsCount} endpoints and stored in project ${result.projectId}`
+      message: `Successfully parsed ${result.endpointsCount} endpoints and stored in project ${result.projectId}`,
     };
   }
 
   @Post('parse-sample-openapi')
   @ApiOperation({ summary: 'Parse the sample OpenAPI file (openapi.json)' })
-  @ApiResponse({ status: 200, description: 'Sample OpenAPI file parsed successfully' })
-  async parseSampleOpenApi(): Promise<{ 
-    status: string; 
-    projectId: number; 
-    endpointsCount: number; 
+  @ApiResponse({
+    status: 200,
+    description: 'Sample OpenAPI file parsed successfully',
+  })
+  async parseSampleOpenApi(): Promise<{
+    status: string;
+    projectId: number;
+    endpointsCount: number;
     message: string;
   }> {
     const filePath = join(__dirname, '../openapi.json');
     const result = await this.openapiService.parseAndStore(filePath);
-    
-    return { 
+
+    return {
       status: 'success',
       projectId: result.projectId,
       endpointsCount: result.endpointsCount,
-      message: `Successfully parsed Swagger Petstore API with ${result.endpointsCount} endpoints`
+      message: `Successfully parsed Swagger Petstore API with ${result.endpointsCount} endpoints`,
     };
   }
 
   @Post('chat')
-  @ApiOperation({ summary: 'Echo chat message' })
-  @ApiResponse({ status: 200, description: 'Message echoed back' })
-  async chat(@Body('message') message: string): Promise<{ echo: string }> {
-    return { echo: `You said: ${message}` };
+  @ApiOperation({ summary: 'Resolve intent and suggest endpoint' })
+  @ApiResponse({ status: 200, description: 'Chosen endpoint for the message' })
+  async chat(@Body('message') message: string): Promise<any> {
+    const endpoint = await this.openapiService.findBestEndpoint(message);
+    if (!endpoint) {
+      return { message: 'No endpoints available' };
+    }
+    return {
+      chosenEndpoint: `${endpoint.method} ${endpoint.path}`,
+      prompt: endpoint.prompt,
+    };
   }
 }


### PR DESCRIPTION
## Summary
- generate prompts for each endpoint when an OpenAPI file is uploaded
- store prompts in the `Endpoint` entity
- resolve chat messages to the best matching endpoint
- document the new capabilities in the README
- add `string-similarity` dependency for simple intent matching

## Testing
- `npm test`
- `npm run lint` *(fails: many eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_686073abb8a0832eaca5a4443c572a9d